### PR TITLE
Reorganise cohorts content around content for two use cases

### DIFF
--- a/app/guide/class-lists.md
+++ b/app/guide/class-lists.md
@@ -1,0 +1,47 @@
+---
+title: Adding class lists
+group: Sessions
+order: 29
+---
+
+To ensure you have an accurate cohort before a school session, Mavis allows you to import individual school class lists. Mavis will update the cohort list with any contact details provided and automatically identify and movers in and out. 
+
+Class lists from each school can be uploaded using the following template:
+
+{% from "attachment/macro.njk" import attachment %}
+{{ attachment({
+  text: "Class list import template",
+  summary: "Microsoft Excel spreadsheet, 17 KB",
+  href: "/files/class-list-import-template.xlsx"
+}) }}
+
+Class lists for each school are uploaded separately, and each school can only have one class list.
+
+Mavis will identify any children not present in the class list as movers out and prompt you to remove them from the school. This will record their new school as unknown until they appear in another school list.
+
+## Uploading a class list file
+
+First, you need to reformat the class list provided by the school ready for upload:
+
+1. Navigate to the relevant Excel file for the school and open it. If there are multiple tabs in the Excel sheet, the records need to be combined into a single table.
+2. If present, remove the helper text row from the table (row 2).
+3. Go to **File > Save a copy** and then choose the format **CSV UTF-8 (Comma delimited) (.csv)** and save it.
+
+In Mavis:
+
+1. Go to **Programmes**.
+2. Go to **HPV**.
+3. Go to the correct school.
+4. Select **Import class list**.
+5. Choose the .csv version of the class list and select **Continue**. If there are any validation issues, Mavis will not import the file. Correct the issues listed and try again.
+6. Wait for the file to finish importing.
+
+## Reviewing children who have moved schools
+
+![Screenshot of page showing children who have moved into a school.](/assets/images/session-moved-in.png 'Mavis shows a list of all the children who appeared in the school list, but weren’t in the cohort for that school before.')
+
+1. Go to **Review children who have changed schools**.
+2. Go to the **Moved in** tab.
+3. Confirm or ignore the change of school for each child as appropriate.
+4. Go to the **Moved out** tab. Mavis shows a list of all the children who were at the school in the cohort list, but weren’t in the class list.
+5. Confirm or ignore the change of school for each child as appropriate.

--- a/app/guide/cohorts.md
+++ b/app/guide/cohorts.md
@@ -88,45 +88,6 @@ Go to the **Import issues** tab. For each record:
 
 If there are some parts of each that are correct, you can note down any correct information from the version you choose to discard, discard it, then go to the child’s record and manually edit the information there (this feature will be more developed in a future release of Mavis).
 
-## Uploading class lists
-
-Class lists can be uploaded using the following template:
-
-{{ attachment({
-  text: "Class list import template",
-  summary: "Microsoft Excel spreadsheet, 17 KB",
-  href: "/files/class-list-import-template.xlsx"
-}) }}
-
-Class lists for each school are uploaded separately, and each school can only have one class list.
-
-The class list must contain the entire cohort for that school, otherwise any children not listed will be removed from the school on Mavis (and recorded as school unknown).
-
-First, you need to reformat the class list provided by the school ready for upload:
-
-1. Navigate to the relevant Excel file for the school and open it. If there are multiple tabs in the Excel sheet, the records need to be combined into a single table.
-2. Remove the helper text row from the table (row 2).
-3. Go to **File > Save a copy** and then choose the format **CSV UTF-8 (Comma delimited) (.csv)** and save it.
-
-In Mavis:
-
-1. Go to **Programmes**.
-2. Go to **HPV**.
-3. Go to the correct school.
-4. Select **Import class list**.
-5. Choose the .csv version of the class list and select **Continue**. If there are any validation issues, Mavis will not import the file. Correct the issues listed and try again.
-6. Wait for the file to finish importing.
-
-### Reviewing children who have moved schools
-
-![Screenshot of page showing children who have moved into a school.](/assets/images/session-moved-in.png 'Mavis shows a list of all the children who appeared in the school list, but weren’t in the cohort for that school before.')
-
-1. Go to **Review children who have changed schools**.
-2. Go to the **Moved in** tab.
-3. Confirm or ignore the change of school for each child as appropriate.
-4. Go to the **Moved out** tab. Mavis shows a list of all the children who were at the school in the cohort list, but weren’t in the class list.
-5. Confirm or ignore the change of school for each child as appropriate.
-
 ## Manually editing individual child records
 
 1. Go to **Children**.

--- a/app/guide/cohorts.md
+++ b/app/guide/cohorts.md
@@ -9,59 +9,45 @@ eleventyComputed:
 
 [[toc]]
 
-## Creating the initial cohort list (year 8 to 11)
+## Introduction
+
+Mavis can be used in one of two ways:
+
+- with complete age-based cohorts, including those already vaccinated in previous academic years (all year 8 to 11s)
+- with unvaccinated cohorts only (all year 8s, and year 9 to 11 catch up lists).
+
+Mavis works better, particularly for reporting and monitoring uptake, when complete, age-based cohorts are imported before the programme begins.
+
+To use Mavis with complete cohorts, as well as importing cohort details, you will also need to upload historic vaccination records for year 9 - 11s vaccinated in previous academic years. If these cannot be imported into Mavis, then you can set up Mavis with records for just the unvaccinated cohorts.
+
+## Setting up complete, age-based cohorts in Mavis
+
+### Creating the initial cohort lists (all year 8 to 11s)
 
 {% from "inset-text/macro.njk" import insetText %}
 {{ insetText({
   html: "You should upload cohort records before you upload vaccination records or class lists."
 }) }}
 
-Cohort records can be uploaded using the following template:
-
-{% from "attachment/macro.njk" import attachment %}
-{{ attachment({
-  text: "Cohort import template",
-  summary: "Microsoft Excel spreadsheet, 18 KB",
-  href: "/files/cohort-import-template.xlsx"
-}) }}
-
 You should include all the year 8, 9, 10 and 11 children in your area, whether they have already been vaccinated or not.
 
-Make sure the cohort records are in the format shown in the template above. Files need to be in .csv format. Records can be all in one file, or split across multiple files; Mavis is not picky about this. If you have an excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
+To upload cohort records and resolve any issues with the import, follow the instructions on this page:
 
-1. Go to **Programmes**.
-2. Go to **HPV**.
-3. Go to the **Cohorts** tab.
-
-![Screenshot of programme cohorts tab.](/assets/images/programme-cohorts.png 'Mavis shows the number of children within each programme cohort.')
-
-For each of your cohort CSV files:
-
-1. Select **Import child records**.
-2. Select **Choose File**.
-3. Open the file and select **Continue**. If there are any validation issues, Mavis will not import the file. Correct the issues listed in the file and try again.
-4. Wait for the file to finish importing.
-
-### Resolving issues importing a cohort list
-
-Mavis will highlight any potential duplicates found with discrepancies between what was uploaded and what was already in Mavis.
-
-Go to the **Import issues** tab. For each record:
-
-1. Select **Review**.
-2. Select which version of the record you want to keep and select resolve duplicate.
-
-If there are some parts of each that are correct, you can note down any correct information from the version you choose to discard, discard it, then go to the child record and manually edit the information there (this feature will be more developed in a future release of Mavis).
+- [Upload cohort records](/guide/uploading-cohorts/)
 
 Once you have uploaded all the cohort files, you can go to the **Cohorts** tab and check the counts for each year group are as expected.
 
-## Importing historic vaccination records (year 9, 10 and 11)
+You can also check individual children’s records by navigating to the **Children** tab. You won’t be able to see the children listed under their school in the sessions tab until you have imported historic vaccination records and scheduled at least one session at that school.
+
+### Importing historic vaccination records (years 9, 10 and 11)
+
+You should upload historic vaccination records before scheduling school sessions, to ensure that only unvaccinated children are added to a session. (But don’t worry, if you identify that someone is already vaccinated at a later date, you can remove them from the session).
 
 When you’re uploading vaccination records, use the same template you’d use for NIVS. You should upload all vaccination records from the last 3 years.
 
 You should also include vaccination records for anyone in the current cohort who was vaccinated elsewhere, if you have them. These records will be stored in Mavis and won’t be sent anywhere else.
 
-Vaccination record files need to be in .csv format. Records can be all in one file, or split across multiple files; Mavis is not picky about this. If you have an excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
+Vaccination record files need to be in .csv format. Records can be all in one file, or split across multiple files; Mavis is not picky about this. If you have an Excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
 
 1. Go to **Programmes**.
 2. Select the programme you want.
@@ -77,9 +63,11 @@ For each of your vaccination record CSV files:
 4. Correct the issues listed and try again.
 5. Wait for the file to finish importing.
 
-### Resolving issues importing historic vaccination records
+Once the file has finished importing, there may be some import issues which you need to review before doing anything else.
 
-Mavis will highlight any potential duplicates found between what was uploaded and what was already in Mavis.
+#### Resolving issues importing historic vaccination records
+
+Mavis will highlight any potential duplicates found in the uploaded file and compared with what was already in Mavis as an import issue.
 
 Go to the **Import issues** tab. For each record:
 
@@ -87,6 +75,43 @@ Go to the **Import issues** tab. For each record:
 2. Select which version of the record you want to keep and select resolve duplicate.
 
 If there are some parts of each that are correct, you can note down any correct information from the version you choose to discard, discard it, then go to the child’s record and manually edit the information there (this feature will be more developed in a future release of Mavis).
+
+### Checking cohorts and what to do next
+
+Once you have uploaded all the cohort files and vaccination records, you can go to the **Cohorts** tab and check the counts for each year group show the number of children who need to be vaccinated in this programme year. 
+
+You can also check individual children’s records by navigating to the **Children** tab. However, you won’t be able to see the children listed under their school in the sessions tab until you have scheduled at least one session at that school. 
+
+Once you have confirmed that the cohort and vaccination records are successfully uploaded, you can proceed to:
+
+- [Scheduling school sessions](/guide/sessions/) or
+- [Adding class lists](/guide/class-lists/)
+
+## Setting up unvaccinated cohorts only in Mavis
+
+### Creating the initial cohort lists (year 8s and unvaccinated year 9 to 11s)
+
+{% from "inset-text/macro.njk" import insetText %}
+{{ insetText({
+  html: "You should upload cohort records before you upload class lists."
+}) }}
+
+You should only include records for children in the year 9, 10 and 11 cohorts who haven’t already been vaccinated in previous years. If a cohort record is uploaded into Mavis without a corresponding vaccination record, then that child will receive a consent request, so it is important if you are not uploading historic vaccination records to filter out anyone who is already vaccinated at the cohorting stage.
+
+To upload cohort records and resolve any issues with the import, follow the instructions on this page:
+
+- [Upload cohort records](/guide/uploading-cohorts/)
+
+### Checking cohorts and what to do next
+
+Once you have uploaded all the cohort files, you can go to the Cohorts tab and check the counts for each year group are as expected. 
+
+You can also check individual children’s records by navigating to the Children tab. However, you won’t be able to see the children listed under their school in the sessions tab until you have scheduled at least one session at that school. 
+
+Once you have confirmed that the cohort is successfully uploaded, you can proceed to:
+
+- [Scheduling school sessions](/guide/sessions/)
+- [Adding class lists](/guide/class-lists/)
 
 ## Manually editing individual child records
 

--- a/app/guide/uploading-cohorts.md
+++ b/app/guide/uploading-cohorts.md
@@ -1,0 +1,42 @@
+---
+title: Uploading cohort records
+group: Programmes
+order: 12
+---
+
+Cohort records can be uploaded using the following template:
+
+{% from "attachment/macro.njk" import attachment %}
+{{ attachment({
+  text: "Cohort import template",
+  summary: "Microsoft Excel spreadsheet, 18 KB",
+  href: "/files/cohort-import-template.xlsx"
+}) }}
+
+Make sure the cohort records are in the format shown in the template above. Files need to be in .csv format. Records can be all in one file, or split across multiple files; Mavis is not picky about this. If you have an excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
+
+1. Go to **Programmes**.
+2. Go to **HPV**.
+3. Go to the **Cohorts** tab.
+
+![Screenshot of programme cohorts tab.](/assets/images/programme-cohorts.png 'Mavis shows the number of children within each programme cohort.')
+
+For each of your cohort CSV files:
+
+1. Select **Import child records**.
+2. Select **Choose File**.
+3. Open the file and select **Continue**. If there are any validation issues, Mavis will not import the file. Correct the issues listed in the file and try again.
+4. Wait for the file to finish importing.
+
+Once the file has finished importing, there may be some import issues which you need to review before doing anything else.
+
+### Resolving issues importing a cohort list
+
+Mavis will highlight any potential duplicates found in the uploaded file and compared with what was already in Mavis as an import issue.
+
+Go to the **Import issues** tab. For each record:
+
+1. Select **Review**.
+2. Select which version of the record you want to keep and select resolve duplicate.
+
+If there are some parts of each that are correct, you can note down any correct information from the version you choose to discard, discard it, then go to the child record and manually edit the information there (this feature will be more developed in a future release of Mavis).


### PR DESCRIPTION
Also move content on uploading class lists and cohort records into separate pages.