### PR TITLE
Mention new mandatory VACCINE_GIVEN field for not given records

### DIFF
--- a/app/guide/record-offline.md
+++ b/app/guide/record-offline.md
@@ -45,8 +45,9 @@ To record a vaccination offline if the child was vaccinated:
 If a child was not vaccinated:
 
 1. Choose ‘N’ from the dropdown menu in the vaccinated column.
-2. Choose the correct reason why the vaccine was not performed in the relevant column using the dropdown menu.
-3. Any notes about the vaccination should be added to the notes column.
+2. Enter the name of the vaccination that was not given in the `VACCINE_GIVEN` column, so we can link the vaccination record with the right programme in Mavis.
+3. Choose the correct reason why the vaccine was not performed in the relevant column using the dropdown menu.
+4. Any notes about the vaccination should be added to the notes column.
 
 ### Entering valid information
 


### PR DESCRIPTION
Adds extra help for what to do with the `VACCINE_GIVEN` column when submitting the offline recording spreadsheet for when a child was not vaccinated:

> Enter the name of the vaccination that was not given in the `VACCINE_GIVEN` column, so we can link the vaccination record with the right programme in Mavis.