### PR TITLE
Update all places referencing Get verbal consent button

### DIFF
--- a/app/guide/community-clinics.md
+++ b/app/guide/community-clinics.md
@@ -40,7 +40,7 @@ This will happen 3 weeks before the date of the first scheduled clinic.
 
 ### If the child belongs to a school but did not get vaccinated there
 
-Some children may have missed being vaccinated at a school session, for example if they were ill or on holiday at the time of the session. 
+Some children may have missed being vaccinated at a school session, for example if they were ill or on holiday at the time of the session.
 
 To send clinic invitations to children who belong to a school, but were not vaccinated there:
 1. Go to **Sessions**
@@ -89,5 +89,5 @@ You could also try to get consent over the phone. To do this:
 
 1. In the **Community clinic** page, go to the **Consent** tab and filter for **No response**.
 2. Click into the child’s record.
-3. Click on **Get verbal consent**.
+3. Click on **Record a new consent response**.
 4. Phone the parent and work through the consent flow to record their response in Mavis.

--- a/app/guide/gillick.md
+++ b/app/guide/gillick.md
@@ -20,7 +20,7 @@ To assess Gillick competence for a child with no consent response:
 
 If the child is assessed as Gillick competent, you still need to add a consent response:
 
-1. Under the Consent response section on the child’s record and click on **Get verbal consent**.
+1. Under the Consent response section on the child’s record and click on **Record a new consent response**.
 
 ![Screenshot of selecting a Gillick competent child.](/assets/images/session-consent-gillick-competent.png)
 

--- a/app/guide/paper-forms.md
+++ b/app/guide/paper-forms.md
@@ -20,11 +20,11 @@ If you receive a request to send a parent a paper-based consent form, you can do
 
 ## Entering a consent response from a paper form
 
-Once the parent returns the form, you can enter the information given into Mavis using the 'Get verbal consent' flow.
+Once the parent returns the form, you can enter the information given into Mavis using the 'Record a new consent response' flow.
 
 1. From the **Consent** tab of a session page, filter for **No response**.
 2. Go to into a child record by clicking on their name.
-3. Select **Get verbal consent**.
+3. Select **Record a new consent response**.
 4. Use the radio button to indicate who’s responded.
 5. Go through the consent flow, making sure to select **Paper** as the way the response was given.
 

--- a/app/guide/verbal-consent.md
+++ b/app/guide/verbal-consent.md
@@ -8,7 +8,7 @@ If you phone a parent to get verbal consent before a session starts, you can rec
 
 1. From the **Consent** tab of a session page, filter for children with **No response**.
 2. Go into a child record by clicking on their name.
-3. Select **Get verbal consent**.
+3. Select **Record a new consent response**.
 4. Use the radio button to indicate who you’re trying to get consent from (you can add a new contact if necessary).
 5. Call the parent.
 6. Record their response.


### PR DESCRIPTION
The button label in Mavis production has been updated to "Record a new consent response".