### PR TITLE
Replace reference to session tabs with filters

### DIFF
--- a/app/guide/attendance.md
+++ b/app/guide/attendance.md
@@ -12,7 +12,7 @@ You can only record vaccinations for children who are registered as attending a 
 To register children as attending or absent, the session must be in progress.
 
 1. Go to **Sessions**.
-2. Go to the **Today** tab.
+2. Filter for **In Progress** sessions.
 3. Click on the name of the school you’re attending.
 4. Click on the **Register** tab.
 5. You’ll see a list of all children for this session - you can use the ‘Not registered yet’ filter if you only want to see children who have not been registered yet.

--- a/app/guide/community-clinics.md
+++ b/app/guide/community-clinics.md
@@ -13,7 +13,7 @@ Any child can be vaccinated at a clinic. Their parent or guardian will need to b
 To create dates for community clinics:
 
 1. Go to **Sessions**.
-2. Go to the **Unscheduled** tab.
+2. Filter for **Unscheduled** sessions.
 3. Go to the **Community clinic** link.
 4. Click on **Schedule sessions**.
 5. Follow the process as you would for school sessions.
@@ -21,7 +21,7 @@ To create dates for community clinics:
 To add or amend dates for community clinics:
 
 1. Go to **Sessions**.
-2. Go to the **Scheduled** tab.
+2. Filter for **Scheduled** sessions.
 3. Go to the **Community clinic** link (there is just one for all clinics).
 4. Go to **Edit session**.
 5. Follow the process as you would for school sessions.
@@ -44,7 +44,7 @@ Some children may have missed being vaccinated at a school session, for example 
 
 To send clinic invitations to children who belong to a school, but were not vaccinated there:
 1. Go to **Sessions**
-2. Go to the **Completed** tab
+2. Filter for **Completed** sessions
 3. Go to the relevant school session
 4. Go to the **Send clinic invitations** link. This will show you a summary of how many invitations will be sent out
 5. Click the **Send clinic invitations** button
@@ -57,9 +57,10 @@ To send clinic invitations to children who belong to a school, but were not vacc
 
 To send booking reminders for subsequent clinics:
 1. Go to **Sessions**
-2. Go to the **Community clinics** link under the **Scheduled** tab
-3. Go to **Send booking reminders**. This will show you a summary of children you can invite again to the next clinic
-4. Click the **Send booking reminders** button
+2. Filter for **Scheduled** sessions
+3. Go to the **Community clinics** link
+4. Go to **Send booking reminders**. This will show you a summary of children you can invite again to the next clinic
+5. Click the **Send booking reminders** button
 
 You will only be able to send clinic booking reminders to parents of children that have been invited for a previous clinic, but have still not been vaccinated. You can only send one invitation per child per clinic session date.
 

--- a/app/guide/consent-responses.md
+++ b/app/guide/consent-responses.md
@@ -9,8 +9,8 @@ order: 10
 Mavis lets you review consent responses for each session.
 
 1. Go to **Sessions**.
-2. Go to the **Scheduled** tab.
-3. Click the link for the school you’re interested in.
+2. Filter for **Scheduled** sessions.
+3. Select the relevant location.
 4. Go to the **Consent** tab.
 5. Use the filters to see how many consents, refusals and conflicts you have - a list of children matching the filters you’ve used will display.
 6. Click on a child’s name if you want to see more details about consent for that child.

--- a/app/guide/paper-forms.md
+++ b/app/guide/paper-forms.md
@@ -11,8 +11,8 @@ eleventyComputed:
 
 If you receive a request to send a parent a paper-based consent form, you can download and print the relevant form from Mavis.
 
-1. Go to **Sessions**, then the **Scheduled** tab.
-2. Find the relevant school.
+1. Go to **Sessions**, then filter for **Scheduled** sessions.
+2. Select the relevant location.
 3. On the school page, click on the **Download consent form** link for the relevant vaccination programme.
 4. You can then print the form off and send it to the parent who requested it.
 

--- a/app/guide/record-offline.md
+++ b/app/guide/record-offline.md
@@ -16,7 +16,7 @@ The vaccination record spreadsheet contains a record for all children in the ses
 To download the spreadsheet for a session:
 
 1. Go to **Sessions**.
-2. Go to the **Scheduled** tab.
+2. Filter for **Scheduled** sessions.
 3. Click the link for the school you’re interested in.
 4. Click on the **Record offline** link at the top of the page to download the Excel file.
 5. Save this locally.

--- a/app/guide/recording-vaccinations.md
+++ b/app/guide/recording-vaccinations.md
@@ -12,7 +12,7 @@ To record a vaccination (or a vaccination that didn’t happen), follow the inst
 ## Select the child and programme
 
 1. Go to **Sessions**.
-2. Go to the **Today** tab.
+2. Filter for **In Progress** sessions.
 3. Click on the name of the school you’re attending.
 4. Click on **Record vaccinations** under the relevant programme.
 5. A list of children’s names is displayed - you can filter the list by name or year group.

--- a/app/guide/sessions.md
+++ b/app/guide/sessions.md
@@ -12,7 +12,7 @@ eleventyComputed:
 You can select which vaccination programmes you are running at a session.
 
 1. Go to **Sessions**.
-2. Find the session you would like to modify within the different tabs on the **Sessions** page.
+2. Find the session you would like to modify by searching for the location name or using the filters in the left-hand column.
 3. Go to **Edit session**.
 4. Under **Programmes**, go to the **Change** link, and select which programmes you are offering at this session.
 
@@ -23,7 +23,7 @@ You can select which vaccination programmes you are running at a session.
 You should only schedule sessions after you’ve uploaded vaccination records and class lists.
 
 1. Go to **Sessions**.
-2. Go to the **Unscheduled** tab.
+2. Filter for **Unscheduled** sessions.
 3. Select a location.
 4. Go to **Schedule sessions**.
 5. Go to **Add session dates**.

--- a/app/guide/sharing-consent.md
+++ b/app/guide/sharing-consent.md
@@ -25,7 +25,7 @@ You’ll also need to let the schools know when they should send the different m
 To get the URL for the consent form:
 
 1. Go to **Sessions**.
-2. Go to the **Scheduled** tab.
+2. Filter for **Scheduled** sessions.
 3. Click on the link for the relevant school.
 4. On the right side of the page, you’ll see links for the consent forms for the different vaccination programmes.
 5. If you click on this link, you will get the URL you need to use in the email template.

--- a/app/guide/triage.md
+++ b/app/guide/triage.md
@@ -7,8 +7,8 @@ order: 14
 Parents’ responses to health questions can be triaged for each school in a session.
 
 1. Go to **Sessions**.
-2. Go to the **Scheduled** tab.
-3. Click the link for the school you’re interested in.
+2. Filter for **Scheduled** sessions.
+3. Select the location you’re interested in.
 4. Go to the **Triage** tab and filter for **Triage needed**.
 
 ![Screenshot of a session overview page.](/assets/images/session.png)


### PR DESCRIPTION
In v2.13 we change the layout of the Sessions page to have filters rather than various tabs splitting sessions.