### PR TITLE
Add school class list request email template

### DIFF
--- a/app/_layouts/email-template.njk
+++ b/app/_layouts/email-template.njk
@@ -22,8 +22,13 @@
         description: description
       }) }}
 
+      {% set insetText = "Replace placeholders with the correct names, dates and URLs." %}
+      {% if showConsentHint | default(true) %}
+        {% set insetText = insetText + " The consent URL is different for every school." %}
+      {% endif %}
+
       {{ nhsukInsetText({
-        text: "Replace placeholders with the correct names, dates and URLs. The consent URL is different for every school."
+        text: insetText
       }) }}
 
       <article class="app-email nhsuk-u-reading-width">

--- a/app/email-templates/class-list-request.md
+++ b/app/email-templates/class-list-request.md
@@ -1,0 +1,61 @@
+---
+title: Class list request
+theme: Schools
+subject: Providing pupil information for vaccinations
+showConsentHint: false
+order: 7
+---
+
+Dear ==name of school== 
+ 
+We need to know which pupils are eligible for vaccination in your school so we can plan the vaccination sessions.  
+ 
+The pupil information is usually kept in a school information management system (IMS) such as Arbor, Bromcom or SIMS. 
+ 
+You need to send us the information in spreadsheet columns for every child: 
+  
+- First name 
+- Surname 
+- Registration group 
+- Date of birth 
+- Address postcode 
+- Parent 1 name 
+- Parent 1 email 
+- Parent 1 phone number 
+- Parent 2 name 
+- Parent 1 email 
+- Parent 1 phone number 
+ 
+You can also see these columns in the template attached. 
+ 
+When choosing a time range for the data, use the 2025 to 2026 school year. 
+ 
+You must save it as a comma delimited (.CSV) file and email it to ==email address==.
+
+You can legally share this information with us under data protection laws, see [school immunisation programmes on GOV.UK](https://www.gov.uk/guidance/data-protection-in-schools/sharing-personal-data#school-immunisation-programmes).
+
+ 
+### Support 
+ 
+Some of the common IMSs have online guides to help you get the information into the right format. For example: 
+ 
+- Arbor has a series of web pages 
+[https://support.arbor-education.com/hc/en-us/articles/28414594882717-Creating-reports-from-scratch-Step-1-Titles-and-Topics]([https://support.arbor-education.com/hc/en-us/articles/28414594882717-Creating-reports-from-scratch-Step-1-Titles-and-Topics)  
+ 
+- Bromcom also has web pages  
+[https://docs.bromcom.com/knowledge-base/how-to-build-a-quick-report-web-wednesday-training/](https://docs.bromcom.com/knowledge-base/how-to-build-a-quick-report-web-wednesday-training/)  
+ 
+- SIMS has a variety of different products, and no single web page of advice, but it does allow users to contact its support team, who can help you
+[https://id.sims.co.uk/support/wiki/21/support-contact](https://id.sims.co.uk/support/wiki/21/support-contact)  
+
+sign-off text here, for example: Thank you for your help
+==name of SAIS team== 
+ 
+==attach template==
+
+{% from "attachment/macro.njk" import attachment %}
+{{ attachment({
+  text: "Class list import template",
+  summary: "Microsoft Excel spreadsheet, 17 KB",
+  href: "/files/class-list-import-template.xlsx"
+}) }}


### PR DESCRIPTION
This template can be sent by SAIS teams to schools to request class list information. It includes support links for major IMSs to hopefully make the process easier for schools, and reduce data handling on SAIS teams end.