### PR TITLE
Fix doubles consent request email

### DIFF
--- a/app/email-templates/consent-request-doubles.md
+++ b/app/email-templates/consent-request-doubles.md
@@ -5,51 +5,56 @@ subject: MenACWY and Td/IPV vaccinations for ==patient name==
 order: 5
 ---
 
-We wrote to you recently to let you know we're coming to ==location name== on ==next session dates== to offer your child their ==vaccination==.
+We’re coming to ==location name== on ==next session dates== to offer the following vaccinations to your child:
 
-If you want your child to be vaccinated, you need to give consent by ==consent deadline==.
+* MenACWY
+* Td/IPV (also called the 3-in-1 teenage booster)
 
-If you’ve already responded to the consent request, you can ignore this message.
+We would like your consent to vaccinate ==short patient name==. You can give this by filling in our online form (the link is below).
 
-### About the MenACWY vaccine
+## About the MenACWY vaccine
 
 The MenACWY vaccine helps protect against life-threatening illnesses including meningitis, sepsis and septicaemia (blood poisoning).
 
 It is recommended for all teenagers. Most people only need 1 dose of the vaccine.
 
 [Find out more about the MenACWY vaccine on NHS.UK](https://www.nhs.uk/vaccinations/menacwy-vaccine/)
-[Read the patient information leaflet for the MenACWY vaccine](https://www.medicines.org.uk/emc/files/pil.12818.pdf)
 
-### About the Td/IPV vaccine
+[Learn about the MenACWY vaccine on GOV.UK](https://www.gov.uk/government/publications/menacwy-vaccine-information-for-young-people) (with links to information in other languages)
 
-The Td/IPV vaccine helps protect against tetanus, diphtheria and polio.
+
+## About the Td/IPV vaccine
+
+The Td/IPV vaccine (3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.
 
 It’s offered at around 13 or 14 years old (school year 9 or 10). It boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/) vaccine.
 
 [Find out more about the Td/IPV vaccine on NHS.UK](https://www.nhs.uk/vaccinations/td-ipv-vaccine-3-in-1-teenage-booster/)
-[Read the patient information leaflet for the Td/IPV vaccine](https://www.medicines.org.uk/emc/files/pil.5581.pdf)
 
-### How to respond
+[Learn about the Td/IPV vaccine on GOV.UK](https://www.gov.uk/government/publications/a-guide-to-the-3-in-1-teenage-booster-tdipv) (with links to information in other languages)
 
-> [!NOTE]
+## How to respond
+
 > It’s important to let us know whether you do or do not want your child to have these vaccinations. It will take less than 5 minutes to respond using the link below.
 
-==consent URL==
+[Respond to the consent request](==consent link==)
 
-### Talk to your child about what they want
+You need to respond by ==consent deadline==.
+
+## Talk to your child about what they want
 
 We suggest you talk to your child about the vaccinations before you respond to us.
 
 Young people have the right to refuse vaccinations. Those who show [‘Gillick competence'](https://www.nhs.uk/conditions/consent-to-treatment/children/) have the right to consent to vaccinations themselves. Our team may assess Gillick competence during vaccination sessions.
 
-### If you cannot use the online form
+## If you cannot use the online form
 
 If you cannot use the online form, you can respond over the phone using the contact details below.
 
-### Your data
+## Your data
 
-By responding, you’re agreeing to your data being processed as set out in our ==privacy notice URL==.
+By responding, you’re agreeing to your data being processed as set out in our [privacy notice](==team privacy notice url==).
 
-### Get in touch with us
+## Get in touch with us
 
-Speak to a member of our team by calling ==team phone number==, or email ==team email address==.
+Speak to a member of our team by calling ==subteam phone==, or email ==subteam email==.


### PR DESCRIPTION
Previously, this was displaying the body of the consent reminder email.

<img width="736" alt="image" src="https://github.com/user-attachments/assets/2c6d7f66-9824-4ea6-b01b-3c3c18dd782a" />