### PR TITLE
Clarifying SystmOne data flows

### DIFF
--- a/app/guide/reporting.md
+++ b/app/guide/reporting.md
@@ -12,6 +12,14 @@ You can also use the Programme area to download reports showing what vaccination
 
 You do not need to share reports for flu or HPV with GPs (except in some cases of self-consent), as [Mavis does this automatically](/guide/recording-vaccinations.md) but you still need to download and share reports with the local CHIS team.
 
+## Data sharing between CHIS, SAIS GP practices on SystmOne
+
+Where vaccination records are sent to GP practices that use SystmOne, and the local CHIS provider also uses SystmOne, then these records may automatically appear in the CHIS system (subject to data sharing agreements). In these areas where SystmOne is used in by many providers, any vaccinations given in Mavis for children whose GP uses EMIS Web or Medicus will need to be manually extracted from Mavis and sent to CHIS.
+
+The same thing also applies where a SAIS provider uses SystmOne as an EPR: data for children whose GP practice uses EMIS Web or Medicus will need to be manually extracted from Mavis and uploaded to the SAIS SystmOne system.
+
+## Downloading vaccination reports
+
 To download vaccination reports:
 
 1. Go to **Programmes**.


### PR DESCRIPTION
Where GP practices are on S1 and CHIS or SAIS providers are too, data for children at these practices is likely to just appear on their systems as a result of the API integration in Mavis. However, where children are at EMIS or Medicus practices, data will need to be manually extracted from Mavis and sent to CHIS or uploaded to SAIS EPRs.

This change clarifies this for SAIS teams.