### PR TITLE
Add note to 'Uploading vaccination records' page and other content tweaks

### DIFF
--- a/app/national-reporting/uploading-vaccination-records.md
+++ b/app/national-reporting/uploading-vaccination-records.md
@@ -33,9 +33,14 @@ For more detailed information about the columns that must be included in the CSV
 
 You may need to refresh the page to see the latest status.
 
+> [!NOTE]
+> You do not need to wait for one file to finish uploading before starting another upload.
+>
+> You can upload multiple files one after the other. Each file will appear in the Incomplete uploads list while it is being processed.
+
 ## Unsuccessful upload
 
-If there are any validation issues, Mavis will not import the file. It will stay on the **Incomplete imports** list with its status marked as invalid.
+If there are any validation issues, Mavis will not import the file. It will stay on the **Incomplete uploads** list with its status marked as invalid.
 
 ### Viewing and resolving upload issues
 
@@ -50,7 +55,7 @@ You should then:
 
 ## Successful upload
 
-If the file was imported successfully it will no longer be visible on the **Incomplete imports** list. It will now be on the **Completed imports** list.
+If the file was imported successfully it will no longer be visible on the **Incomplete uploads** list. It will now be on the **Completed imports** list.
 
 You can find it by selecting the **Completed imports** tab.
 

--- a/app/national-reporting/uploading-vaccination-records.md
+++ b/app/national-reporting/uploading-vaccination-records.md
@@ -31,7 +31,7 @@ For more detailed information about the columns that must be included in the CSV
 3. Select **Continue**.
 4. You can see the file’s status on the **Incompleted imports** list.
 
-You may need to refresh the page to see the latest status.
+You may need to refresh the page to see the latest status. You can check the upload status at any time.
 
 > [!NOTE]
 > You do not need to wait for one file to finish uploading before starting another upload.


### PR DESCRIPTION
Make it clear to users that they don't need to wait for a file to finish uploading before they start to upload another file.