### PR TITLE
Minor content tweak

### DIFF
--- a/app/guide/manage-consent-reminders.md
+++ b/app/guide/manage-consent-reminders.md
@@ -12,7 +12,7 @@ You can also send reminders manually. Mavis will then skip the next automatic re
 
 1. Go to **Sessions**.
 2. Find the session you’re interested in and select it.
-3. On the **Overview** page, you’ll see how many children do not have a consent response. In the **Action required** block, select the **Send reminders** link. This takes you to the **Manage consent reminders** page.
+3. On the **Overview** page, you’ll see how many children do not have a consent response. In the **Action required** section, select the **Send reminders** link. This takes you to the **Manage consent reminders** page.
 4. On this page you can see how many parents have not responded. To send them a reminder, select the **Send manual consent reminders** button. Reminders are sent instantly.
 
 ![Screenshot of Manage consent reminders page.](/assets/images/manage-consent-reminders.png)


### PR DESCRIPTION
Replace 'block' with 'section' when talking about the session overview page, to make language consistent across the guide.