### PR TITLE
Clarifications on 'Reviewing and adding PSDs' page

### DIFF
--- a/app/guide/reviewing-and-adding-psds.md
+++ b/app/guide/reviewing-and-adding-psds.md
@@ -8,7 +8,7 @@ You can review and add patient specific directions (PSDs) to named children in f
 
 Note that:
 
-- this feature must be turned on for the session (see previous page)
+- this feature must be turned on for the session (see [Enabling PSDs in Mavis](/guide/enabling-psds/))
 - only prescribers can add PSDs
 - all users can see each child’s PSD status
 
@@ -47,11 +47,12 @@ If you select Yes, the PSDs will be bulk-added instantly.
 
 Prescribers can also add PSDs to individual children during triage if they assess it’s safe for them to have the nasal spray vaccine.
 
-## If a child’s triage status changes
+## If a child’s consent or triage status changes
 
 If a child has a PSD in place, Mavis will automatically remove it if:
 
+- a parent withdraws their consent for the child to be vaccinated
 - a new consent response indicates triage is needed
 - a nurse updates the child’s triage status to ‘Needs triage’
 
-The prescriber can add a new PSD if they decide it’s safe for the child to have the nasal spray vaccine.
+A prescriber can add a new PSD once the child meets the criteria for vaccination (consent is in place, there is no conflicting consent response, and triage is not needed).


### PR DESCRIPTION
Clarify that Mavis automatically removes a PSD if a parent withdraws consent.