### PR TITLE
Small updates to 'Registering attendance' page

### DIFF
--- a/app/guide/attendance.md
+++ b/app/guide/attendance.md
@@ -22,12 +22,16 @@ To register a child as attending or absent:
 1. Go to **Sessions**.
 2. Filter for **In Progress** sessions.
 3. Find the session you’re interested in and select it.
-4. Filter for **Not registered yet**. You’ll see a list of all children who have not been registered yet.
-5. Find the child’s name, then select the **Attending** or **Absent** button.
+4. The **Action required** area on the **Overview** tab shows how many children have not been registered yet. Select the link (for example, **36 children to register**) to see the list of children.
+5. Find the child’s name, then select **Attending** or **Absent**.
 
 ![Screenshot of a register attendance page.](/assets/images/session-attendance.png 'You must register attendance before you can record vaccinations.')
 
-You can update a child’s attendance status if you need to, while the session is in progress.
+You can also find children who still need to be registered on the **Children in session** tab by selecting **Not registered yet** under **Registration status**.
 
-1. From the **Children** tab, find the child whose attendance you want to update.
-2. Select the **Attending** or **Absent** button to update their status.
+## Changing a child's attendance status
+
+You can change a child’s attendance status while a session is in progress.
+
+1. From the **Children in session** tab, find the child whose attendance you want to update.
+2. Select **Attending** or **Absent** to update their status.


### PR DESCRIPTION
Explain 'register attendance' link in Action required area of session overview. Update name of 'Children in session' tab.