### PR TITLE
Improve user guide content on uploading files

### DIFF
--- a/app/guide/class-lists.md
+++ b/app/guide/class-lists.md
@@ -11,12 +11,21 @@ Before a session takes place, you’ll need to get an up-to-date class list from
 You can use our [school class list request email template]({{ "/email-templates-for-sais-and-schools/class-list-request" | absoluteUrl }}), if needed, when requesting this information from schools.
 
 > [!NOTE]
-> You must upload class lists at least 3 weeks before the session date, as this is when Mavis sends consent requests to parents.
+> You should upload class lists at least 3 weeks before the session date, as this is when Mavis sends consent requests to parents.
 
 Uploading class lists:
 
 - adds parent contact details for children in the session, which Mavis uses to send consent requests
 - identifies children who have moved in our out of the school since you uploaded the cohort
+
+Make sure you upload class lists separately for each school. Each school can only have one class list.
+
+Before uploading a class list, read:
+
+- [what to upload and when](/what-to-upload-and-when/)
+- [preparing files for upload](/preparing-files-for-upload/)
+
+## How to upload a class list
 
 You can use this template:
 
@@ -27,10 +36,6 @@ You can use this template:
   href: "/files/class-list-upload-template.xlsx"
 }) }}
 
-Make sure you upload class lists separately for each school. Each school can only have one class list.
-
-## Uploading a class list file
-
 If the school did not provide the list in CSV format, you need to reformat it ready for upload:
 
 1. Navigate to the relevant Excel file for the school and open it. If there are multiple tabs in the Excel sheet, the records need to be combined into a single table.
@@ -39,31 +44,36 @@ If the school did not provide the list in CSV format, you need to reformat it re
 
 In Mavis:
 
-1. Go to **Imports** in the top navigation.
+1. Go to the **Imports** tab.
 2. Select **Upload records**.
 3. Select **Class list records** then **Continue**.
 4. Search for the school by name and select **Continue**.
 5. Select which year groups these records are for.
-6. Select **Choose File**, then select the CSV file you want to import.
-7. Select **Continue**. If there are any validation issues, Mavis will not import the file. Correct the issues listed in the file and try again.
+6. Select **Choose File**, then select the CSV file you want to upload.
+7. Select **Continue**. If there are any validation issues, Mavis will not upload the file. Correct the issues listed in the file and try again.
 8. Wait for the file to finish uploading.
 
 Mavis may add a missing NHS number or replace an incorrect one in your upload by searching PDS. (See [See how Mavis uses PDS to find NHS numbers](importing-cohorts.md#see-how-mavis-uses-pds-to-find-nhs-numbers))
 
 > [!NOTE]
-> If a school does not provide postcodes for every child, you can still upload the class lists. You will have to add any missing NHS numbers manually.
+> If a school does not provide postcodes for every child, you can still upload the class list. You will have to add any missing NHS numbers manually.
 
-## Upload errors
+### Upload errors
 
 If your upload fails, see [Upload errors](/guide/importing-cohorts/#upload-errors).
 
-## Reviewing and approving uploads
+> [!NOTE]
+> If less than 70% of records, uploaded with a postcode, match an NHS number in PDS, the upload will be rejected, and you’ll see an error message. You should review the file, correcting any formatting issues (for example, make sure the first name and last name columns and the date of birth rows are in the correct position) and try uploading it again.
 
-After you successfully upload a class list, Mavis checks the records and shows a summary of what will happen if you confirm the upload. Review the results and select **Approve and import records** to continue, or **Cancel and delete upload**.
+### Reviewing and approving uploads
+
+After the file has uploaded, you must review and approve it before the records are imported into Mavis.
+
+Select the upload date and time to open the review page.
 
 ![Screenshot of review screen for class import.](/assets/images/review-class-import.png)
 
-### Records already in Mavis
+#### Records already in Mavis (no action needed)
 
 When you upload class lists, Mavis identiies children it already has records for.
 
@@ -71,38 +81,52 @@ If it’s an exact duplicate, Mavis will simply not import the record again - yo
 
 If the file upload includes additional information for the child, such as their gender or preferred name, this will be added to the existing record if you approve the upload.
 
-### Close matches to existing records
+#### Close matches to existing records (resolve after import)
 
 If Mavis identifies any close matches to existing child records, you will need to review the missing or conflicting details after approving the upload, and confirm which record to keep and which record to archive.
 
-Click **Approve and import records**
+#### School moves (resolve after import)
 
-You’ll need to review close matches and school moves after importing.
+If the upload includes children who already have a record in Mavis for a different school, Mavis flags this as a school move. Mavis also flags when a child moves to a school in your area from a school outside your area.
 
-1. Click **Review** for each record listed.
-2. For close matches, select which version of the record you want to keep and select **Resolve duplicate**.
+If you approve the upload, you must confirm the child’s school in the School moves area of Mavis.
 
-There is also an option to keep both child records. For example, in the case of twins, Mavis will identify a near match, but you can select **Keep both records**. The existing record will stay in Mavis and the uploaded record will be added.
+[Find out how to review and resolve school moves](/guide/school-moves/).
+
+### Approving the upload (and further reviews)
+
+To approve the upload and import the records into Mavis, select **Approve and import records**.
+
+> [!NOTE]
+> Once a file upload has been approved and imported into Mavis, it will no longer be visible in the **Incomplete uploads** list. It will now be in the **Completed imports** list. You can find it by selecting the Completed imports tab.
+
+In some cases, you will need to do a **further review**. This happens if one or more records have changed since you uploaded the file.
+
+For example, another import may have been approved that includes some of the same records, or a child’s school or NHS number may have changed in Mavis.
+
+Review the changed records and confirm whether you still want to import them.
+
+## Resolving close matches
+
+Mavis highlights any potential duplicates as **close matches to existing records**, which you must resolve after import.
+
+1. On the Imports screen, select the **Completed imports** tab.
+2. Select the date and time of the upload to view its details.
+3. Under ‘Close matches to existing records - needs review’, select the **upload issues** link to see a list of close matches.
+4. Select **Review** for each record listed.
+5. Select which version of the record you want to keep then select **Resolve duplicate**.
+
+You can also choose to keep both child records. For example, Mavis may identify twins as a close match. If this happens, select **Keep both records**.
 
 If each record contains some correct information:
 
-1. Note any correct information from the record you plan to archive.
+1. Note any correct information from the record you are not keeping.
 2. Go to the record you are keeping and edit the information there.
-3. Archive the record you no longer need.
+
+Mavis also highlights if the NHS number you provided for a child is different from the NHS number held by PDS. If this happens, Mavis automatically replaces the incorrect NHS number with the correct one from PDS (see below).
 
 > [!NOTE]
-> If less than 70% of records, uploaded with a postcode, match an NHS number in PDS, the upload will be rejected, and you’ll see an error message. You should review the file, correcting any formatting issues (for example, make sure the first name and last name columns and the date of birth rows are in the correct position) and try uploading it again.
-
-> [!NOTE]
-> Some records may have changed since you uploaded your file. For example, another import might have been approved that includes some of the records in your file, or a child's school or NHS number may have changed in Mavis. If this happens, you’ll need to review those records again and confirm you still want to import the remaining changes from your file.
-
-### School moves
-
-Mavis will automatically identify if a child’s school has changed and raise this on the School moves page.
-
-To review a child changing school, follow the instructions on this page of the user guide:
-
-- [Reviewing school moves](school-moves.md)
+> You can view all unresolved close matches in the **Issues tab** on the Imports screen. This lists outstanding close matches from all uploads.
 
 ## Handling out-of-year-group children
 

--- a/app/guide/class-lists.md
+++ b/app/guide/class-lists.md
@@ -123,8 +123,6 @@ If each record contains some correct information:
 1. Note any correct information from the record you are not keeping.
 2. Go to the record you are keeping and edit the information there.
 
-Mavis also highlights if the NHS number you provided for a child is different from the NHS number held by PDS. If this happens, Mavis automatically replaces the incorrect NHS number with the correct one from PDS (see below).
-
 > [!NOTE]
 > You can view all unresolved close matches in the **Issues tab** on the Imports screen. This lists outstanding close matches from all uploads.
 

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -144,13 +144,9 @@ For example, another import may have been approved that includes some of the sam
 
 Review the changed records and confirm whether you still want to import them.
 
-### Resolving close matches
+### Resolving possible duplicates
 
-You will need to review close matches and school moves after importing records.
-
-If you confirm that the child has moved to a school in your area from another team’s area, the original team will be notified. [Find out how to review and resolve school moves](/guide/school-moves/).
-
-Resolve close matches in the Imports area:
+Mavis highlights any potential duplicates as **close matches to existng records**, which you must resolve after import.
 
 1. On the Imports screen, select the **Completed imports** tab.
 2. Select the date and time of the upload to view its details.

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -146,7 +146,7 @@ Review the changed records and confirm whether you still want to import them.
 
 ### Resolving close matches
 
-Mavis highlights any potential duplicates as **close matches to existng records**, which you must resolve after import.
+Mavis highlights any potential duplicates as **close matches to existing records**, which you must resolve after import.
 
 1. On the Imports screen, select the **Completed imports** tab.
 2. Select the date and time of the upload to view its details.

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -11,15 +11,6 @@ eleventyComputed:
 
 > [!NOTE]
 > You should upload cohort records before you upload vaccination records or class lists.
->
-> ## Before you start
-
-Read:
-
-- [what to upload and when](/what-to-upload-and-when/)
-- preparing files for upload
-
-## Setting up your cohort
 
 When your team first starts using Mavis, you need to upload records for all children in your area.
 
@@ -36,9 +27,12 @@ At the start of each school year, upload records for children entering Reception
 
 You can also add new children to the cohort at any time by uploading records for individual or multiple children.
 
-When children are taught outside their chronological year group, you’ll need to record this in either the cohort upload or class list upload - for more details, see ‘Handling out-of-year-group children’ below.
+Before you start, read:
 
-### What details to include
+- [what to upload and when](/what-to-upload-and-when/)
+- [preparing files for upload](/preparing-files-for-upload/)
+  
+## What details to include
 
 You must include the following information for each child in the cohort:
 
@@ -60,7 +54,7 @@ For a full list of details you can upload, see the cohort upload template.
 If you do not include a child’s NHS number, we’ll retrieve it from the Personal Demographics Service (PDS) - Mavis [automatically searches PDS](importing-cohorts.md#see-how-mavis-uses-pds-to-find-nhs-numbers) to find a match for the child, using the information you’ve provided (their date of birth must be correct for this to work).
 
 
-### How to upload a cohort file
+## How to upload a cohort file
 
 1. From the dashboard, go to **Import records** (or click on Imports in the top navigation).
 2. Select **Upload records** near the top of the page.
@@ -71,7 +65,7 @@ If you do not include a child’s NHS number, we’ll retrieve it from the Perso
 > [!NOTE]
 > Large cohort files can fail to upload, due to their size. If your CSV file has over 10,000 rows, we recommend you split it into smaller files - for example 2 files with 5,000 rows.
 
-### Checking the upload status
+## Checking the upload status
 
 You can see whether your file was successfully uploaded by checking its status in the list of uploads.
 
@@ -80,7 +74,7 @@ You can see whether your file was successfully uploaded by checking its status i
 
 ![Screenshot of uploads table.](/assets/images/import_statuses.png)
 
-### Upload errors
+## Upload errors
 
 If there are validation issues, Mavis will not import the file. It will stay in the **Incomplete imports** list with its status marked as **Invalid**.
 

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -65,7 +65,7 @@ If you do not include a child’s NHS number, we’ll retrieve it from the Perso
 > [!NOTE]
 > Large cohort files can fail to upload, due to their size. If your CSV file has over 10,000 rows, we recommend you split it into smaller files - for example 2 files with 5,000 rows.
 
-## Checking the upload status
+### Checking the upload status
 
 You can see whether your file was successfully uploaded by checking its status in the list of uploads.
 
@@ -74,7 +74,7 @@ You can see whether your file was successfully uploaded by checking its status i
 
 ![Screenshot of uploads table.](/assets/images/import_statuses.png)
 
-## Upload errors
+### Upload errors
 
 If there are validation issues, Mavis will not import the file. It will stay in the **Incomplete imports** list with its status marked as **Invalid**.
 
@@ -90,7 +90,7 @@ You should then:
 > [!NOTE]
 > If less than 70% of records match an NHS number in PDS, the upload will be rejected, and you’ll see an error message. You should review the file, correcting any formatting issues (for example, make sure the first name and last name columns and the date of birth rows are in the correct position) and try uploading it again.
 
-## Reviewing and approving uploads
+### Reviewing and approving uploads
 
 After the file has uploaded, you must review and approve it before the records are imported into Mavis.
 
@@ -98,7 +98,7 @@ Select the upload date and time to open the review page.
 
 ![Screenshot of review screen for cohort import.](/assets/images/review-cohort-import.png)
 
-### Records already in Mavis (no action needed)
+#### Records already in Mavis (no action needed)
 
 When you upload child records, Mavis checks whether it already has a record for that child.
 
@@ -107,13 +107,13 @@ If a record is an exact duplicate, Mavis will simply not import it again. You’
 > [!NOTE]
 > If the upload includes additional information about the child, such as their gender or preferred name, this information will be added to the existing record if you approve the upload.
 
-### Close matches to existing records (resolve after import)
+#### Close matches to existing records (resolve after import)
 
 If the upload includes close matches with existing child records, you’ll need to review them after you approve the upload.
 
 Check the missing or conflicting details and decide which record to keep and which to archive. We explain how to do this below.
 
-### School moves (resolve after import)
+#### School moves (resolve after import)
 
 If the upload includes children who already have a record in Mavis for a different school, Mavis flags this as a school move.
 Mavis also flags when a child moves to a school in your area from a school outside your area.
@@ -123,7 +123,7 @@ If you approve the upload, you must confirm the child’s school in the School m
 If you confirm that the child has moved to a school in your area from another team’s area, the original team will be notified.
 [Find out how to review and resolve school moves](/guide/school-moves/).
 
-### Children with no known school already registered at a school in a different area (no action needed)
+#### Children with no known school already registered at a school in a different area (no action needed)
 
 If the upload includes children with no known school who are already registered at a school (or registered as home-educated) in another SAIS team’s area, Mavis will not import these records.
 
@@ -131,7 +131,7 @@ The records will remain with the other team and will not appear in your area.
 
 If you upload the records again with updated school information, Mavis will import them as a school move if the school is in your area.
 
-## Approving the upload (and further reviews)
+### Approving the upload (and further reviews)
 
 To approve the upload and import the records into Mavis, select **Approve and import records**.
 

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -144,7 +144,7 @@ For example, another import may have been approved that includes some of the sam
 
 Review the changed records and confirm whether you still want to import them.
 
-### Resolving possible duplicates
+### Resolving close matches
 
 Mavis highlights any potential duplicates as **close matches to existng records**, which you must resolve after import.
 

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -131,7 +131,7 @@ The records will remain with the other team and will not appear in your area.
 
 If you upload the records again with updated school information, Mavis will import them as a school move if the school is in your area.
 
-### Approving the upload (and further reviews)
+## Approving the upload (and further reviews)
 
 To approve the upload and import the records into Mavis, select **Approve and import records**.
 
@@ -144,7 +144,7 @@ For example, another import may have been approved that includes some of the sam
 
 Review the changed records and confirm whether you still want to import them.
 
-### Resolving close matches
+## Resolving close matches
 
 Mavis highlights any potential duplicates as **close matches to existing records**, which you must resolve after import.
 

--- a/app/guide/importing-cohorts.md
+++ b/app/guide/importing-cohorts.md
@@ -161,8 +161,6 @@ If each record contains some correct information:
 1. Note any correct information from the record you are not keeping.
 2. Go to the record you are keeping and edit the information there.
 
-Mavis also highlights if the NHS number you provided for a child is different from the NHS number held by PDS. If this happens, Mavis automatically replaces the incorrect NHS number with the correct one from PDS (see below).
-
 > [!NOTE]
 > You can view all unresolved close matches in the **Issues tab** on the Imports screen. This lists outstanding close matches from all uploads.
 
@@ -172,7 +170,7 @@ Mavis also highlights if the NHS number you provided for a child is different fr
 
 ## See how Mavis uses PDS to find NHS numbers
 
-Mavis may add a missing NHS number or replace an incorrect one in your upload by searching the NHS Patient Demographics Service (PDS) (sometimes referred to as ‘the Spine’).
+If the NHS number you provided for a child is different from the NHS number held by the NHS Patient Demographics Service (PDS) (sometimes referred to as ‘the Spine’), Mavis automatically replaces the incorrect NHS number on the child's record with the correct one from PDS.
 
 If this happens, a PDS history link appears beside the NHS number in the child’s record.
 

--- a/app/guide/preparing-files-for-upload.md
+++ b/app/guide/preparing-files-for-upload.md
@@ -4,9 +4,7 @@ theme: Uploading records to Mavis
 order: 5
 ---
 
-## Before you start
-
-Read an overview of [what records you need to upload to Mavis and when](/what-to-upload-and-when/). 
+Before you start, read an overview of [what records you need to upload to Mavis and when](/what-to-upload-and-when/). 
 
 ## File requirements
 
@@ -21,7 +19,6 @@ If you have an Excel file with multiple tabs, before uploading it check you have
 
 - combined the tabs into a single worksheet before saving it as a CSV file, or 
 - created a separate CSV file for each tab
-
 
 ## Next steps
 

--- a/app/guide/vaccination-history.md
+++ b/app/guide/vaccination-history.md
@@ -6,9 +6,7 @@ order: 7
 
 [[toc]]
 
-You should upload relevant historical vaccination records before scheduling school sessions.
-
-This allows Mavis to:
+You should upload relevant historical vaccination records before scheduling school sessions. This allows Mavis to:
 
 - identify which vaccinations a child has already had
 - only send consent requests for children who have not had the vaccine already
@@ -19,6 +17,11 @@ You should include vaccination records for anyone in the cohort who was vaccinat
 
 Once a child’s record has been added to Mavis, any school age vaccinations they get at a GP practice are automatically added to their record in Mavis.
 
+Before uploading vaccination records, read:
+
+- [what to upload and when](/what-to-upload-and-when/)
+- [preparing files for upload](/preparing-files-for-upload/)
+  
 ## What vaccination history you need to upload
 
 How much vaccination history you need to upload depends on the programme.
@@ -67,13 +70,9 @@ For example, if you’re vaccinating children in Year 9, upload records of Td/IP
 > [!NOTE]
 > Do not upload records of any previous tetanus-, diphtheria- or polio-containing vaccines that are not Td/IPV, for example the 6-in-1 vaccine or the 4-in-1 pre-school booster. Mavis is not authorised to hold this information.
 
-## How to upload historical vaccination records
+## How to upload vaccination records
 
-Use the following template to upload historical vaccination records for HPV, MenACWY and Td/IPV from the last 3 years.
-
-For MMR(V), you should go as far back as the oldest member of the cohort minus one year. For example, if you’re vaccinating Year 6 children (where the oldest child is 11), you’d upload records for the last 10 years. For Year 11 children (where the oldest child is 16), this would mean uploading records for the last 15 years.
-
-This does not apply to flu.
+Use the following template:
 
 {% from "attachment/macro.njk" import attachment %}
 {{ attachment({
@@ -82,42 +81,50 @@ This does not apply to flu.
   href: "/files/historical-vaccination-records-upload-template.xlsx"
 }) }}
 
-Vaccination record files need to be in .csv format. Records can be all in one file, or split across multiple files; Mavis is not picky about this. If you have an Excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
+Vaccination record files need to be in .csv format. Records can be all in one file, or split across multiple files. If you have an Excel file with multiple tabs, you will need to consolidate this into a single tab or create a separate CSV file for each tab.
 
 For each of your vaccination record CSV files:
 
 1. Go to the **Imports** tab.
-2. Click on the **Upload records** button near the top of the page.
+2. Select **Upload records** near the top of the page.
 3. Select **Vaccination records**, then **Continue**.
-4. Click on **Choose File**, then select the CSV file you want to upload.
-5. Click **Continue**. If there are any validation issues, Mavis will not upload the file. Correct the issues listed in the file and try again.
+4. Select **Choose File**, then select the CSV file you want to upload.
+5. Select **Continue**. If there are any validation issues, Mavis will not upload the file. Correct the issues listed in the file and try again.
 6. Wait for the file to finish uploading
 
-Once the file has finished uploading, there may be some import issues which you need to review before doing anything else.
+### Checking the upload status
 
-## Upload errors
+You can see whether your file successfully uploaded by checking its status in the list of uploads.
+
+Once the file has finished uploading, it will no longer be visible in the **Incomplete uploads** tab. It will now be in the **Completed imports** tab. 
+
+### Upload errors
 
 If your upload fails, see [Upload errors](/guide/importing-cohorts/#upload-errors).
 
-## Resolving issues when uploading files
+## Resolving possible duplicates
 
-Mavis will highlight any potential duplicates found in the uploaded file and compared with what was already in Mavis as an upload issue.
+After a file has successfully uploaded, Mavis highlights any potential duplicates as **close matches to existng records**, which you must resolve.
 
-Go to the **Imports** tab. For each record under **Upload issues**:
-
-1. Select **Review**.
-2. Select which version of the record you want to keep and select resolve duplicate.
+1. Go to **Imports** and select the **Completed imports** tab.
+2. Select the date and time of the upload to view its details.
+3. Under ‘Close matches to existing records - needs review’, select the upload issues link to see a list of possible duplicates.
+4. Select **Review** for each record listed.
+5. Select which version of the record you want to keep then select **Resolve duplicate**.
 
 If there are some parts of each that are correct, you can note down any correct information from the version you choose to discard, discard it, then go to the child’s record and manually edit the information there (this feature will be more developed in a future release of Mavis).
+
+> [!NOTE]
+> You can view all unresolved close matches in the **Issues tab** on the Imports screen. This lists outstanding close matches from all uploads.
 
 ## Manually recording a child as 'already vaccinated'
 
 If a child’s historical vaccination record is missing from CHIS data, or you have not been able to upload their historical vaccination record into Mavis, you can manually record the child as ‘already vaccinated’ for a specific programme.
 
 1. From the dashboard, go to **Children**.
-2. Search for the child then click on their name to open the child record.
+2. Search for the child then select their name to open the child record.
 3. Select the relevant tab for the vaccination programme you want to record.
-4. Click on the **Record as already vaccinated** button at top of the page.
+4. Select **Record as already vaccinated** at top of the page.
 
 ![Screenshot of Record as already vaccinated button.](/assets/images/record-as-already-vaccinated-button.png)
 
@@ -126,4 +133,4 @@ If a child’s historical vaccination record is missing from CHIS data, or you h
    > [!NOTE]
    > You must know the date of vaccination in order to record it here. You do not need to know the time.
 
-6. Check the details on the page and add a note to explain this was a historical vaccination, then click the **Confirm** button.
+6. Check the details on the page and add a note to explain this was a historical vaccination, then select **Confirm**.

--- a/app/guide/vaccination-history.md
+++ b/app/guide/vaccination-history.md
@@ -90,7 +90,6 @@ For each of your vaccination record CSV files:
 3. Select **Vaccination records**, then **Continue**.
 4. Select **Choose File**, then select the CSV file you want to upload.
 5. Select **Continue**. If there are any validation issues, Mavis will not upload the file. Correct the issues listed in the file and try again.
-6. Wait for the file to finish uploading
 
 ### Checking the upload status
 

--- a/app/guide/vaccination-history.md
+++ b/app/guide/vaccination-history.md
@@ -72,7 +72,7 @@ For example, if you’re vaccinating children in Year 9, upload records of Td/IP
 
 ## How to upload vaccination records
 
-Use the following template:
+Use this template:
 
 {% from "attachment/macro.njk" import attachment %}
 {{ attachment({


### PR DESCRIPTION
This PR:
- tries to make our approach and content on uploading files consistent across all 3 upload types (especially uploading cohorts and uploading class lists, which have a lot of overlap)
- removes unnecessary detail (eg we link to the school moves page, so no need to say much on these page)

This is an intermediate step. We can see the areas of duplication between the 3 files (especially uploading cohorts and uploading class lists) and consider whether we're happy to keep the duplication or rework it on a shared page. 