### PR TITLE
New school year update

### DIFF
--- a/app/guide/preparing-new-school-year.md
+++ b/app/guide/preparing-new-school-year.md
@@ -13,7 +13,7 @@ In this period you can see 2 academic years in the Mavis filters so you can deci
 
 ![Screenshot of session filters showing two academic years.](/assets/images/academic-year-filters.png)
 
-Before 1 September you must:
+Between 1 August and 1 September you must:
 
 - upload new cohorts that were not already in Mavis - you only need to upload the new cohort, all the others are already in Mavis (when you upload a cohort or class list, make sure the YEAR_GROUP column in the CSV file shows the school year the child will be in from 1 September)
 - check cohorts and any important notices

--- a/app/guide/preparing-new-school-year.md
+++ b/app/guide/preparing-new-school-year.md
@@ -1,5 +1,5 @@
 ---
-title: Preparing for a new school year
+title: Preparing for a new academic year
 theme: Managing cohorts
 order: 15
 eleventyComputed:

--- a/app/guide/preparing-new-school-year.md
+++ b/app/guide/preparing-new-school-year.md
@@ -7,21 +7,24 @@ eleventyComputed:
     key: Preparing for a new school year
 ---
 
-The month of August is when we prepare for the next school year.
+The month of August is when we prepare for the next academic year.
 
-In this period you can see 2 school years in the Mavis filters so you can decide whether to view or manage records for the previous school year or the next one.
+In this period you can see 2 academic years in the Mavis filters so you can decide whether to view or manage records for the previous year or the next one.
 
 ![Screenshot of session filters showing two academic years.](/assets/images/academic-year-filters.png)
 
-From 1 August you can:
+Before 1 September you must:
 
-- import new cohorts that were not already in Mavis - you only need to import the new cohort, all the others are already in Mavis (when you upload a cohort or class list, make sure the YEAR_GROUP column in the CSV file shows the school year the child will be in from 1 September)
+- upload new cohorts that were not already in Mavis - you only need to upload the new cohort, all the others are already in Mavis (when you upload a cohort or class list, make sure the YEAR_GROUP column in the CSV file shows the school year the child will be in from 1 September)
 - check cohorts and any important notices
 - review school moves - see [Reviewing school moves](school-moves.md)
+- upload vaccination history
+- upload full class lists
 - schedule sessions - at least the sessions due to take place in the next month need to be scheduled in Mavis so that consent invitations can go out to parents in time - see [Scheduling and editing sessions](sessions.md)
-- invite some children to clinics, for example if they are immunosuppressed and need to be prioritised for flu vaccination - see [Vaccinating in community clinics](community-clinics.md)
 
-All consent, triage, and PSD results expire at the end of each school year so you will need to add this information again in the new school year.
+You can also invite some children to clinics, for example if they are immunosuppressed and need to be prioritised for flu vaccination - see [Vaccinating in community clinics](community-clinics.md).
+
+All consent, triage, and PSD results expire at the end of each academic year so you will need to add this information again in the new academic year.
 
 Any children who are eligible for vaccination but have moved to a year group not supported by their school (for example Year 6 children moving to year 7 or children leaving middle schools) will be automatically assigned to '**No known school**' (until you upload the new cohort).
 


### PR DESCRIPTION
Changed 'school year' to 'academic year' to reflect language used and distinguish from 'school year' in 1st bullet. 
Clarified instructions that users must do / can do.