### PR TITLE
Missing links in email templates in user guide

### DIFF
--- a/app/email-templates-for-sais-and-schools/changing-consent-process-for-parents.md
+++ b/app/email-templates-for-sais-and-schools/changing-consent-process-for-parents.md
@@ -30,7 +30,7 @@ To allow the NHS immunisation team to contact you, we will give them:
 
 These details will only be used to send messages about your child’s vaccinations.
 
-You can find more information about the school age vaccination schedule on the NHS website.
+[Find out more about the school age vaccination schedule on the NHS website](https://www.nhs.uk/vaccinations/nhs-vaccinations-and-when-to-have-them/)
 
 ### Keeping your information safe
 

--- a/app/email-templates-for-sais-and-schools/changing-consent-process-for-schools.md
+++ b/app/email-templates-for-sais-and-schools/changing-consent-process-for-schools.md
@@ -20,9 +20,9 @@ In ==month== we’ll ask you to provide:
 
 We’ll use these contact details to send consent requests and reminders.
 
-You can legally share this information with us under data protection laws - see school immunisation programmes on GOV.UK.
+You can legally share this information with us under data protection laws - see [school immunisation programmes on GOV.UK](https://www.gov.uk/guidance/data-protection-in-schools/sharing-personal-data#school-immunisation-programmes).
 
-You can find more information on GOV.UK about how schools can support vaccination programmes.
+You can find more information on GOV.UK about [how schools can support vaccination programmes](https://www.gov.uk/government/publications/health-protection-in-schools-and-other-childcare-facilities/supporting-immunisation-programmes#the-role-of-education-and-childcare-settings).
 
 ### How we keep information secure
 


### PR DESCRIPTION
- add missing links to GOV.UK guidance in the template 'Tell schools you’re changing the way you manage consent for vaccinations'
- add missing link to NHS.UK guidance in the template 'Tell parents about changes to how consent will be requested'