### PR TITLE
Clinics pilot guidance make space for new pages

### DIFF
--- a/app/guide/reporting.md
+++ b/app/guide/reporting.md
@@ -1,7 +1,7 @@
 ---
 title: Downloading vaccination reports
 theme: Statistics and reports
-order: 66
+order: 81
 ---
 
 [[toc]]

--- a/app/guide/sharing-vaccination-records-between-mavis-and-systmone.md
+++ b/app/guide/sharing-vaccination-records-between-mavis-and-systmone.md
@@ -1,7 +1,7 @@
 ---
 title: Sharing vaccination records between Mavis and SystmOne
 theme: Statistics and reports
-order: 67
+order: 82
 eleventyComputed:
   eleventyNavigation:
     key: Sharing vaccination records with SystmOne

--- a/app/guide/statistics-for-vaccinations-and-schools.md
+++ b/app/guide/statistics-for-vaccinations-and-schools.md
@@ -1,7 +1,7 @@
 ---
 title: Viewing consent and vaccination data
 theme: Statistics and reports
-order: 65
+order: 80
 ---
 
 [[toc]]


### PR DESCRIPTION
This PR updates the page order of the final 3 pages of the user guide so there is space to insert new guidance pages for the clinics pilot. 