### PR TITLE
Add a privacy notice for the childhood vaccination history alpha

### DIFF
--- a/app/childhood-vaccination-history-privacy-notice.md
+++ b/app/childhood-vaccination-history-privacy-notice.md
@@ -1,0 +1,57 @@
+---
+layout: page
+date: 2026-07-30
+title: "Childhood vaccination history alpha: Privacy notice"
+---
+
+## Background
+
+Accurate, understandable and up-to-date shared vaccination history is vital for the delivery of both routine vaccination programmes and targeted catch-up campaigns. It helps inform clinical providers which patients are eligible to be offered a vaccination and enables commissioners to plan programmes, monitor uptake and, in partnership with the UKHSA, understand coverage and efficacy. Availability of up-to-date information relevant to their children will inform and empower parents and guardians to manage their children’s health.
+
+## What is NHS England doing?
+
+NHS England staff working on Manage vaccinations in schools (Mavis) are undertaking a piece of work to understand how to generate and present to clinicians and parents an accurate, understandable and up-to-date shared vaccination history.
+
+As part of that work, we are asking a set of parents who have previously agreed to take part in research to give us consent to view their children’s MMR vaccination records in Mavis.
+
+Those vaccination records may include vaccinations recorded by school age immunisation services, vaccination records from the GP data held by NHS England, and the vaccination records held for your child by the relevant Child Health Information Services (CHIS).
+
+We know that there are gaps and inconsistencies in vaccination records held by these services. When we look at a child’s vaccination record, we will use what we find:
+
+- to understand how vaccination records are recorded and where there are any gaps or inconsistencies
+- to inform the design of children’s vaccination records that parents can check
+
+Children's vaccination records are stored securely in the NHS Mavis database and will remain there. We will not move or copy them.
+
+Taking part is voluntary and will not affect any child's care.
+
+For parents who consent for us to look at their child’s records:
+
+- we will only view their child's vaccination record – we cannot make changes to it
+- we will not send the parents a copy of their child's record as part of this project
+- we will only have access to their child's record for the period necessary for the research, and for a maximum of 6 months
+- no clinical decisions will be made based on our work
+
+Parents who would like to view their child's vaccination records can see them on the NHS App or by contacting their GP.
+
+## Who will have access to children's records?
+
+Access is restricted to a limited set of named members of the NHS England team. The names of members of the team will be shared with parents invited to give consent.
+
+## What will happen once parents consent to us accessing their child’s records?
+
+We may contact some parents to take part in a short interview. If they are selected, a researcher will share their screen to show the parent their child's record and ask them about it. Parents are under no obligation to take part in an interview and declining will not affect anything.
+
+If parents are not selected for an interview, they will not hear from us again in connection with this project.
+
+## Withdrawing consent
+
+Parents can withdraw consent at any time by emailing [england.mavisresearch@nhs.net](mailto:england.mavisresearch@nhs.net).
+
+If parents withdraw, we will stop accessing their child's record and any data already collected will not be used. If a parent withdraws consent, we won't delete their child's records – they are legally held for that child's care – but we will no longer use them in this work.
+
+## Parent data and privacy
+
+Parents’ personal information and their child's record will be treated confidentially and stored securely. Only the named team members will have access. We will not share any information about any child’s vaccinations with anyone else.
+
+Personal information collected as part of this research, such as parental consent responses and contact details, will be kept for a maximum of 2 years in line with NHS England data retention requirements.


### PR DESCRIPTION
This is deliberately not linked from anywhere else in the user guide, it is just made available in order that we can link to it from other research recruitments and consent materials.

<img width="2392" height="6400" alt="Screen Shot 2026-07-30 at 18 10 46" src="https://github.com/user-attachments/assets/5c47ff82-b1fa-45e6-b8a5-7a71097630c2" />

